### PR TITLE
Fix Typo & add link to full example

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Inside the proposed `my()` function is where you actually build the chart as you
 
 ```javascript
 // Append a `g` element to an svg on your DOM in which to render your axis
-var axisG = d3.selecd('#my-svg').append('g');
+var axisG = d3.select('#my-svg').append('g');
 
 // Construct a scale function that exposes getter/setter methods for domain/range
 var scale = d3.scale.linear() // closure function that returns a function...
@@ -328,6 +328,8 @@ chartWrapper.call(myChart);
 ```
 
 For some initial practice working with reusable charts, see [exercise-2](exercise-2).
+
+Here's a [complete working example of a reusable chart](http://bl.ocks.org/curran/66d926fe73211fd650ec).
 
 ## Next Steps
 Whew -- that's a lot. The first step will be to develop a firm understanding of how **getter/setter methods**, **method chaining**, **closures**,  and **D3 selections** work in tandem to create a pattern of reusability. Using this pattern, you can move away from writing one-off scripts for scatter-plots, and move towards reusable charts (as promised). This skeleton code provides a _starting point_ for reusability, but does not lend guidance for many design principles for developing your reusable code. This setup lends itself to many questions:


### PR DESCRIPTION
selecd -> select

Some feedback: IMO, the part that adds the axis should not be doing the selection of `#my-svg`, as in this example code `var axisG = d3.select('#my-svg').append('g');`. I was hoping this was an "on-the-way" example that you'd correct later on, but I don't see any mention of it. Perhaps after you introduce `selection.each`, you could give a modified version of the axis example that appends to the selection that's passed in, rather than selecting the svg.

Also, have you created a bl.ock with a complete example of the reusable charts pattern based on your example code here? The tutorial kind of leaves students hanging at the end, wondering how it can all be put together. I've added a link to a bl.ock I created with the code from @mbostock's original towards reusable charts example.
